### PR TITLE
Add volume/stats API, polish streaming results, and upgrade to Python 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *swp
 *pyc
 *aiodocker*egg*
+build
 dist
 __pycache__
 .cache
+venv
+.env

--- a/aiodocker/channel.py
+++ b/aiodocker/channel.py
@@ -1,18 +1,17 @@
 import asyncio
 
 
-class ChannelIterator:
+class ChannelSubscriber:
     def __init__(self, channel):
-        self.channel = channel
         self.queue = asyncio.Queue()
+        self.channel = channel
         self.channel.queues.append(self.queue)
 
     def __del__(self):
         self.channel.queues.remove(self.queue)
 
-    @asyncio.coroutine
-    def get(self):
-        x = yield from self.queue.get()
+    async def get(self):
+        x = await self.queue.get()
         return x
 
 
@@ -20,10 +19,9 @@ class Channel:
     def __init__(self):
         self.queues = []
 
-    @asyncio.coroutine
-    def put(self, obj):
+    async def publish(self, obj):
         for el in self.queues:
-            yield from el.put(obj)
+            await el.put(obj)
 
-    def listen(self):
-        return ChannelIterator(self)
+    def subscribe(self):
+        return ChannelSubscriber(self)

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -190,8 +190,10 @@ class DockerImages(object):
             if isinstance(auth, dict):
                 auth = json.dumps(auth).encode('utf8')
                 auth = base64.b64encode(auth)
-            if not isinstance(auth, bytes):
-                raise TypeError("auth must be base64 encoded bytes or a dictionary")
+            if not isinstance(auth, (bytes, str)):
+                raise TypeError("auth must be base64 encoded string/bytes or a dictionary")
+            if isinstance(auth, bytes):
+                auth = auth.decode('ascii')
             headers['X-Registry-Auth'] = auth
         if tag:
             params['tag'] = tag

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -591,7 +591,7 @@ class DockerVolumes:
     def create(self, config):
         config = json.dumps(config, sort_keys=True, indent=4).encode('utf-8')
         data = yield from self.docker._query_json(
-            "volumes",
+            "volumes/create",
             method="POST",
             headers={"content-type": "application/json",},
             data=config,

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -55,6 +55,15 @@ class Docker:
         return response
 
     @asyncio.coroutine
+    def auth(self, **credentials):
+        response = yield from self._query_json(
+            "auth", "POST",
+            data=credentials,
+            headers={"content-type": "application/json",},
+        )
+        return response
+
+    @asyncio.coroutine
     def pull(self, image, stream=False):
         response = yield from self._query(
             "images/create", "POST",

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -9,7 +9,6 @@ import tarfile
 import json
 import datetime as dt
 import ssl
-from aiohttp import websocket
 
 from .channel import Channel
 from .utils import identical

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -188,7 +188,7 @@ class DockerImages(object):
         params = {}
         if auth:
             if isinstance(auth, dict):
-                auth = json.dumps(auth)
+                auth = json.dumps(auth).encode('utf8')
                 auth = base64.b64encode(auth)
             if not isinstance(auth, bytes):
                 raise TypeError("auth must be base64 encoded bytes or a dictionary")

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -413,12 +413,13 @@ class DockerContainer:
 
     @asyncio.coroutine
     def kill(self, **kwargs):
-        data = yield from self.docker._query_json(
+        response = yield from self.docker._query(
             "containers/{}/kill".format(self._id),
             method='POST',
             params=kwargs
         )
-        return data
+        yield from response.release()
+        return
 
     @asyncio.coroutine
     def wait(self, timeout=None, **kwargs):

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -11,6 +11,7 @@ import datetime as dt
 import ssl
 
 from .channel import Channel
+from .exceptions import DockerError
 from .utils import identical
 from .multiplexed import MultiplexedResult
 from .jsonstream import JsonStreamResult
@@ -88,9 +89,7 @@ class Docker:
         if (response.status // 100) in [4, 5]:
             what = yield from response.read()
             response.close()
-            raise ValueError("Got a failure from the server: '%s'" % (
-                what.decode('utf-8').strip()
-            ))
+            raise DockerError(response.status, json.loads(what.decode('utf8')))
 
         return response
 
@@ -267,7 +266,7 @@ class DockerContainers(object):
                     yield from container.stop()
                 yield from container.delete()
                 container = None
-        except ValueError:
+        except DockerError:
             pass
 
         if container is None:

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -45,6 +45,16 @@ class Docker:
         self.session = session
 
     @asyncio.coroutine
+    def images(self, **params):
+        #TODO image resource
+        response = yield from self._query_json(
+            "images/json", "GET",
+            params=params,
+            headers={"content-type": "application/json",},
+        )
+        return response
+
+    @asyncio.coroutine
     def pull(self, image, stream=False):
         response = yield from self._query(
             "images/create", "POST",

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -55,6 +55,11 @@ class Docker:
         return response
 
     @asyncio.coroutine
+    def version(self):
+        data = yield from self._query_json("version")
+        return data
+
+    @asyncio.coroutine
     def pull(self, image, stream=False):
         response = yield from self._query(
             "images/create", "POST",

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -1,20 +1,27 @@
-import io
-import os
-import base64
-import urllib
-import aiohttp
 import asyncio
-import hashlib
-import tarfile
-import json
+import base64
+from collections import ChainMap
 import datetime as dt
+import hashlib
+import io
+import json
+import logging
+import os
 import ssl
+import tarfile
+import urllib
+import warnings
+
+import aiohttp
+from async_timeout import timeout as _timeout
 
 from .channel import Channel
 from .exceptions import DockerError
-from .utils import identical
-from .multiplexed import MultiplexedResult
-from .jsonstream import JsonStreamResult
+from .utils import identical, human_bool, httpize
+from .multiplexed import multiplexed_result
+from .jsonstream import json_stream_result
+
+log = logging.getLogger(__name__)
 
 
 class Docker:
@@ -46,101 +53,84 @@ class Docker:
             session = aiohttp.ClientSession(connector=self.connector)
         self.session = session
 
-    @asyncio.coroutine
-    def auth(self, **credentials):
-        response = yield from self._query_json(
+    async def auth(self, **credentials):
+        response = await self._query_json(
             "auth", "POST",
             data=credentials,
             headers={"content-type": "application/json",},
         )
         return response
 
-    @asyncio.coroutine
-    def version(self):
-        data = yield from self._query_json("version")
+    async def version(self):
+        data = await self._query_json("version")
         return data
 
-    @asyncio.coroutine
-    def pull(self, image, stream=False):
-        response = yield from self._query(
+    async def pull(self, image, stream=False):
+        response = await self._query(
             "images/create", "POST",
             params={"fromImage": image},
             headers={"content-type": "application/json",},
         )
-        json_stream = yield from self._json_stream_result(response, stream=stream)
-        return json_stream
+        return (await json_stream_result(response, stream=stream))
 
     def _endpoint(self, path):
         return "/".join([self.url, path])
 
-    @asyncio.coroutine
-    def _query(self, path, method='GET', params=None, timeout=None,
-               data=None, headers=None, **kwargs):
+    async def _query(self, path, method='GET', params=None, timeout=None,
+                     data=None, headers=None, **kwargs):
+        '''
+        Get the response object by performing the HTTP request.
+        The caller is responsible to finalize the response object.
+        '''
         url = self._endpoint(path)
-        future = asyncio.ensure_future(self.session.request(
-            method, url,
-            params=params, headers=headers, data=data, **kwargs))
-
-        if timeout:
-            response = yield from asyncio.wait_for(future, timeout)
-        else:
-            response = yield from future
+        try:
+            with _timeout(timeout):
+                response = await self.session.request(
+                    method, url,
+                    params=httpize(params), headers=headers,
+                    data=data, **kwargs)
+        except asyncio.TimeoutError:
+            raise
 
         if (response.status // 100) in [4, 5]:
-            what = yield from response.read()
+            what = await response.read()
             response.close()
             raise DockerError(response.status, json.loads(what.decode('utf8')))
 
         return response
 
-    @asyncio.coroutine
-    def _result(self, response, response_type=None):
-        if not response_type:
-            ct = response.headers.get("Content-Type", "")
-            if 'json' in ct:
-                response_type = 'json'
-            elif 'x-tar' in ct:
-                response_type = 'tar'
-            elif 'text/plain' in ct:
-                response_type = 'text'
+    @staticmethod
+    async def _result(response, response_type=None):
+        '''
+        Convert the response to native objects by the given response type
+        or the auto-detected HTTP content-type.
+        It also ensures release of the response object.
+        '''
+        try:
+            if not response_type:
+                ct = response.headers.get("Content-Type", "")
+                if 'json' in ct:
+                    response_type = 'json'
+                elif 'x-tar' in ct:
+                    response_type = 'tar'
+                elif 'text/plain' in ct:
+                    response_type = 'text'
+                else:
+                    raise TypeError(f"Unrecognized response type: {ct}")
+            if 'tar' == response_type:
+                what = await response.read()
+                return tarfile.open(mode='r', fileobj=io.BytesIO(what))
+            if 'json' == response_type:
+                data = await response.json(encoding='utf-8')
+            elif 'text' ==  response_type:
+                data = await response.text(encoding='utf-8')
             else:
-                raise TypeError("Unrecognized response type: {}".format(ct))
-        if 'tar' == response_type:
-            what = yield from response.read()
-            yield from response.release()
-            return tarfile.open(mode='r', fileobj=io.BytesIO(what))
+                data = await response.read()
+            return data
+        finally:
+            await response.release()
 
-        if 'json' == response_type:
-            data = yield from response.json(encoding='utf-8')
-        elif 'text' ==  response_type:
-            data = yield from response.text(encoding='utf-8')
-        else:
-            data = yield from response.read()
-
-        yield from response.release()
-        return data
-
-    def _json_stream_result(self, response, transform=None, stream=True):
-        json_stream = JsonStreamResult(response, transform)
-        if stream:
-            return json_stream
-        data = []
-        i = yield from json_stream.__aiter__()
-        while True:
-            try:
-                line = yield from i.__anext__()
-            except StopAsyncIteration:
-                break
-            else:
-                data.append(line)
-
-        return data
-
-    def _multiplexed_result(self, response):
-        return MultiplexedResult(response)
-
-    @asyncio.coroutine
-    def _websocket(self, url, **params):
+    async def _websocket(self, url, **params):
         if not params:
             params = {
                 'stdout': 1,
@@ -148,13 +138,15 @@ class Docker:
                 'stream': 1
             }
         url = self._endpoint(url) + "?" + urllib.parse.urlencode(params)
-        ws = yield from aiohttp.ws_connect(url, connector=self.connector)
+        ws = await aiohttp.ws_connect(url, connector=self.connector)
         return ws
 
-    @asyncio.coroutine
-    def _query_json(self, *args, **kwargs):
-        response = yield from self._query(*args, **kwargs)
-        data = yield from self._result(response, 'json')
+    async def _query_json(self, *args, **kwargs):
+        '''
+        A shorthand of _query() followed by _result() with JSON response type.
+        '''
+        response = await self._query(*args, **kwargs)
+        data = await Docker._result(response, 'json')
         return data
 
 
@@ -162,33 +154,29 @@ class DockerImages(object):
     def __init__(self, docker):
         self.docker = docker
 
-    @asyncio.coroutine
-    def list(self, **params):
-        response = yield from self.docker._query_json(
+    async def list(self, **params):
+        response = await self.docker._query_json(
             "images/json", "GET",
             params=params,
             headers={"content-type": "application/json",},
         )
         return response
 
-    @asyncio.coroutine
-    def get(self, name):
-        response = yield from self.docker._query_json(
-            "images/{0}/json".format(name),
+    async def get(self, name):
+        response = await self.docker._query_json(
+            f"images/{name}/json",
             headers={"content-type": "application/json",},
         )
         return response
 
-    @asyncio.coroutine
-    def history(self, name):
-        response = yield from self.docker._query_json(
-            "images/{0}/history".format(name),
+    async def history(self, name):
+        response = await self.docker._query_json(
+            f"images/{name}/history",
             headers={"content-type": "application/json",},
         )
         return response
 
-    @asyncio.coroutine
-    def push(self, name, tag=None, auth=None, stream=False):
+    async def push(self, name, tag=None, auth=None, stream=False):
         headers = {
             "content-type": "application/json",
             "X-Registry-Auth": "FOO",
@@ -205,34 +193,31 @@ class DockerImages(object):
             headers['X-Registry-Auth'] = auth
         if tag:
             params['tag'] = tag
-        response = yield from self.docker._query(
-            "images/{0}/push".format(name),
+        response = await self.docker._query(
+            f"images/{name}/push",
             "POST",
             params=params,
             headers=headers,
         )
-        json_stream = yield from self.docker._json_stream_result(response, stream=stream)
-        return json_stream
+        return (await json_stream_result(response, stream=stream))
 
-    @asyncio.coroutine
-    def tag(self, name, tag=None, repo=None):
+    async def tag(self, name, tag=None, repo=None):
         params = {}
         if tag:
             params['tag'] = tag
         if repo:
             params['repo'] = repo
-        response = yield from self.docker._query_json(
-            "images/{0}/tag".format(name),
+        response = await self.docker._query_json(
+            f"images/{name}/tag",
             "POST",
             params=params,
             headers={"content-type": "application/json"},
         )
         return response
 
-    @asyncio.coroutine
-    def delete(self, name, **params):
-        response = yield from self.docker._query_json(
-            "images/{0}/tag".format(name),
+    async def delete(self, name, **params):
+        response = await self.docker._query_json(
+            f"images/{name}/tag",
             "DELETE",
             params=params,
             headers={"content-type": "application/json",},
@@ -244,45 +229,42 @@ class DockerContainers(object):
     def __init__(self, docker):
         self.docker = docker
 
-    @asyncio.coroutine
-    def list(self, **kwargs):
-        data = yield from self.docker._query_json(
+    async def list(self, **kwargs):
+        data = await self.docker._query_json(
             "containers/json",
             method='GET',
             params=kwargs
         )
         return [DockerContainer(self.docker, **x) for x in data]
 
-    @asyncio.coroutine
-    def create_or_replace(self, name, config):
+    async def create_or_replace(self, name, config):
         container = None
 
         try:
-            container = yield from self.get(name)
+            container = await self.get(name)
             if not identical(config, container._container):
                 running = container._container.get(
                     "State", {}).get("Running", False)
                 if running:
-                    yield from container.stop()
-                yield from container.delete()
+                    await container.stop()
+                await container.delete()
                 container = None
         except DockerError:
             pass
 
         if container is None:
-            container = yield from self.create(config, name=name)
+            container = await self.create(config, name=name)
 
         return container
 
-    @asyncio.coroutine
-    def create(self, config, name=None):
+    async def create(self, config, name=None):
         url = "containers/create"
 
         config = json.dumps(config, sort_keys=True, indent=4).encode('utf-8')
         kwargs = {}
         if name:
             kwargs['name'] = name
-        data = yield from self.docker._query_json(
+        data = await self.docker._query_json(
             url,
             method='POST',
             headers={"content-type": "application/json",},
@@ -291,10 +273,9 @@ class DockerContainers(object):
         )
         return DockerContainer(self.docker, id=data['Id'])
 
-    @asyncio.coroutine
-    def get(self, container, **kwargs):
-        data = yield from self.docker._query_json(
-            "containers/{}/json".format(container),
+    async def get(self, container, **kwargs):
+        data = await self.docker._query_json(
+            f"containers/{container}/json",
             method='GET',
             params=kwargs
         )
@@ -316,8 +297,7 @@ class DockerContainer:
             "ID", self._container.get("Id")))
         self.logs = DockerLog(docker, self)
 
-    @asyncio.coroutine
-    def log(self, stdout=False, stderr=False, follow=False, **kwargs):
+    async def log(self, stdout=False, stderr=False, follow=False, **kwargs):
         if stdout is False and stderr is False:
             raise TypeError("Need one of stdout or stderr")
 
@@ -328,36 +308,20 @@ class DockerContainer:
         }
         params.update(kwargs)
 
-        response = yield from self.docker._query(
-            "containers/{}/logs".format(self._id),
+        response = await self.docker._query(
+            f"containers/{self._id}/logs",
             method='GET',
             params=params,
         )
-        log_stream = self.docker._multiplexed_result(response)
-        if follow:
-            return log_stream
-        log_lines = []
+        return (await multiplexed_result(response, follow))
 
-        #TODO 3.5 cleans up this syntax
-        i = yield from log_stream.__aiter__()
-        while True:
-            try:
-                line = yield from i.__anext__()
-            except StopAsyncIteration:
-                break
-            else:
-                log_lines.append(line.decode('utf-8'))
-
-        return ''.join(log_lines)
-
-    @asyncio.coroutine
-    def copy(self, resource, **kwargs):
+    async def copy(self, resource, **kwargs):
         #TODO this is deprecated, use get_archive instead
         request = json.dumps({
             "Resource": resource,
         }, sort_keys=True, indent=4).encode('utf-8')
-        data = yield from self.docker._query(
-            "containers/{}/copy".format(self._id),
+        data = await self.docker._query(
+            f"containers/{self._id}/copy",
             method='POST',
             data=request,
             headers={"content-type": "application/json",},
@@ -365,91 +329,82 @@ class DockerContainer:
         )
         return data
 
-    @asyncio.coroutine
-    def put_archive(self, path, data):
-        response = yield from self.docker._query(
-            "containers/{}/archive".format(self._id),
+    async def put_archive(self, path, data):
+        response = await self.docker._query(
+            f"containers/{self._id}/archive",
             method='PUT',
             data=data,
             headers={"content-type": "application/json",},
             params={'path': path}
         )
-        data = yield from self.docker._result(response)
+        data = await Docker._result(response)
         return data
 
-    @asyncio.coroutine
-    def show(self, **kwargs):
-        data = yield from self.docker._query_json(
-            "containers/{}/json".format(self._id),
+    async def show(self, **kwargs):
+        data = await self.docker._query_json(
+            f"containers/{self._id}/json",
             method='GET',
             params=kwargs
         )
         self._container = data
         return data
 
-    @asyncio.coroutine
-    def stop(self, **kwargs):
-        response = yield from self.docker._query(
-            "containers/{}/stop".format(self._id),
+    async def stop(self, **kwargs):
+        response = await self.docker._query(
+            f"containers/{self._id}/stop",
             method='POST',
             params=kwargs
         )
-        yield from response.release()
+        await response.release()
         return
 
-    @asyncio.coroutine
-    def start(self, _config=None, **config):
+    async def start(self, _config=None, **config):
         config = _config or config
         config = json.dumps(config, sort_keys=True, indent=4).encode('utf-8')
-        response = yield from self.docker._query(
-            "containers/{}/start".format(self._id),
+        response = await self.docker._query(
+            f"containers/{self._id}/start",
             method='POST',
             headers={"content-type": "application/json",},
             data=config
         )
-        yield from response.release()
+        await response.release()
         return
 
-    @asyncio.coroutine
-    def kill(self, **kwargs):
-        response = yield from self.docker._query(
-            "containers/{}/kill".format(self._id),
+    async def kill(self, **kwargs):
+        response = await self.docker._query(
+            f"containers/{self._id}/kill",
             method='POST',
             params=kwargs
         )
-        yield from response.release()
+        await response.release()
         return
 
-    @asyncio.coroutine
-    def wait(self, timeout=None, **kwargs):
-        data = yield from self.docker._query_json(
-            "containers/{}/wait".format(self._id),
+    async def wait(self, timeout=None, **kwargs):
+        data = await self.docker._query_json(
+            f"containers/{self._id}/wait",
             method='POST',
             params=kwargs,
             timeout=timeout,
         )
         return data
 
-    @asyncio.coroutine
-    def delete(self, **kwargs):
-        response = yield from self.docker._query(
-            "containers/{}".format(self._id),
+    async def delete(self, **kwargs):
+        response = await self.docker._query(
+            f"containers/{self._id}",
             method='DELETE',
             params=kwargs
         )
-        yield from response.release()
+        await response.release()
         return
 
-    @asyncio.coroutine
-    def websocket(self, **params):
-        url = "containers/{}/attach/ws".format(self._id)
-        ws = yield from self.docker._websocket(url, **params)
+    async def websocket(self, **params):
+        url = f"containers/{self._id}/attach/ws"
+        ws = await self.docker._websocket(url, **params)
         return ws
 
-    @asyncio.coroutine
-    def port(self, private_port):
+    async def port(self, private_port):
         if 'NetworkSettings' not in self._container:
-            yield from self.show()
+            await self.show()
 
         private_port = str(private_port)
         h_ports = None
@@ -469,18 +424,16 @@ class DockerContainer:
 
         return h_ports
 
-    @asyncio.coroutine
-    def stats(self, stream=True):
+    async def stats(self, stream=True):
         if stream:
-            response = yield from self.docker._query(
-                "containers/{}/stats".format(self._id),
+            response = await self.docker._query(
+                f"containers/{self._id}/stats",
                 params={'stream': '1'},
             )
-            json_stream = yield from self.docker._json_stream_result(response)
-            return json_stream
+            return (await json_stream_result(response))
         else:
-            data = yield from self.docker._query_json(
-                "containers/{}/stats".format(self._id),
+            data = await self.docker._query_json(
+                f"containers/{self._id}/stats",
                 params={'stream': '0'},
             )
             return data
@@ -494,52 +447,56 @@ class DockerContainer:
 
 class DockerEvents:
     def __init__(self, docker):
-        self.running = False
         self.docker = docker
         self.channel = Channel()
+        self.json_stream = None
 
     def listen(self):
-        return self.channel.listen()
+        warnings.warn("use subscribe() method instead",
+                      DeprecationWarning, stacklevel=2)
+        return self.channel.subscribe()
 
-    def saferun(self):
-        if self.running:
-            return
-        self.running = True
-        asyncio.async(self.run())
-
-    @asyncio.coroutine
-    def query(self, **params):
-        response = yield from self.docker._query(
-            "events",
-            method="GET",
-            params=params,
-        )
-        json_stream = yield from self.docker._json_stream_result(response, self._transform_event)
-        return json_stream
+    def subscribe(self):
+        return self.channel.subscribe()
 
     def _transform_event(self, data):
         if 'time' in data:
             data['time'] = dt.datetime.fromtimestamp(data['time'])
         return data
 
-    @asyncio.coroutine
-    def run(self):
-        self.running = True
-        containers = self.docker.containers
-        self.json_stream = yield from self.query()
-
-        i = yield from self.json_stream.__aiter__()
-        while True:
+    async def run(self, **params):
+        if self.json_stream:
+            warnings.warn("already running",
+                          RuntimeWarning, stackelevel=2)
+            return
+        forced_params = {
+            'stream': True,
+        }
+        params = ChainMap(forced_params, params)
+        try:
+            response = await self.docker._query(
+                "events",
+                method="GET",
+                params=params,
+            )
+            self.json_stream = await json_stream_result(response,
+                self._transform_event,
+                human_bool(params['stream']),
+            )
+            async for data in self.json_stream.fetch():
+                await self.channel.publish(data)
+        finally:
+            # signal termination to subscribers
+            await self.channel.publish(None)
             try:
-                data = yield from i.__anext__()
-            except (StopAsyncIteration, asyncio.TimeoutError):
-                break
-            else:
-                yield from self.channel.put(data)
-        self.running = False
+                await self.json_stream.close()
+            except:
+                pass
+            self.json_stream = None
 
-    def stop(self):
-        self.json_stream.close()
+    async def stop(self):
+        if self.json_stream:
+            await self.json_stream.close()
 
 
 class DockerLog:
@@ -547,52 +504,67 @@ class DockerLog:
         self.docker = docker
         self.channel = Channel()
         self.container = container
-        self.running = False
+        self.response = None
 
     def listen(self):
-        return self.channel.listen()
+        warnings.warn("use subscribe() method instead",
+                      DeprecationWarning, stacklevel=2)
+        return self.channel.subscribe()
 
-    def saferun(self):
-        if self.running:
+    def subscribe(self):
+        return self.channel.subscribe()
+
+    async def run(self, **params):
+        if self.response:
+            warnings.warn("already running",
+                          RuntimeWarning, stackelevel=2)
             return
-        self.running = True
-        asyncio.async(self.run())
-
-    @asyncio.coroutine
-    def run(self):
-        self.running = True
-        containers = self.docker.containers
-        response = yield from self.docker._query(
-            'containers/{id}/logs'.format(id=self.container._id),
-            params=dict(
-                follow=True,
-                stdout=True,
-                stderr=True,
+        forced_params = {
+            'follow': True,
+        }
+        default_params = {
+            'stdout': True,
+            'stderr': True,
+        }
+        params = ChainMap(forced_params, params, default_params)
+        try:
+            self.response = await self.docker._query(
+                f'containers/{self.container._id}/logs',
+                params=params,
             )
-        )
+            while True:
+                msg = await self.response.content.readline()
+                if not msg:
+                    break
+                await self.channel.publish(msg)
+        except (aiohttp.errors.ClientDisconnectedError,
+                aiohttp.errors.ServerDisconnectedError):
+            pass
+        finally:
+            # signal termination to subscribers
+            await self.channel.publish(None)
+            try:
+                await self.response.release()
+            except:
+                pass
+            self.response = None
 
-        for msg in response:
-            msg = yield from msg
-            asyncio.async(self.channel.put(msg))
-
-        yield from response.release()
-
-        self.running = False
+    async def stop(self):
+        if self.response:
+            await self.response.release()
 
 
 class DockerVolumes:
     def __init__(self, docker):
         self.docker = docker
 
-    @asyncio.coroutine
-    def list(self):
-        data = yield from self.docker._query_json("volumes")
+    async def list(self):
+        data = await self.docker._query_json("volumes")
         return data
 
-    @asyncio.coroutine
-    def create(self, config):
+    async def create(self, config):
         config = json.dumps(config, sort_keys=True, indent=4).encode('utf-8')
-        data = yield from self.docker._query_json(
+        data = await self.docker._query_json(
             "volumes/create",
             method="POST",
             headers={"content-type": "application/json",},
@@ -606,18 +578,16 @@ class DockerVolume:
         self.docker = docker
         self.name = name
 
-    @asyncio.coroutine
-    def show(self):
-        data = yield from self.docker._query_json(
-            "volumes/{}".format(self.name)
+    async def show(self):
+        data = await self.docker._query_json(
+            f"volumes/{self.name}"
         )
         return data
 
-    @asyncio.coroutine
-    def delete(self):
-        response = yield from self.docker._query(
-            "volumes/{0}".format(name),
+    async def delete(self):
+        response = await self.docker._query(
+            f"volumes/{self.name}",
             method="DELETE",
         )
-        yield from response.release()
+        await response.release()
         return

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -613,9 +613,9 @@ class DockerVolume:
 
     @asyncio.coroutine
     def delete(self):
-        response = yield from self.docker._query_json(
+        response = yield from self.docker._query(
             "volumes/{0}".format(name),
             method="DELETE",
-            headers={"content-type": "application/json",},
         )
-        return response
+        yield from response.release()
+        return

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -532,10 +532,10 @@ class DockerEvents:
         while True:
             try:
                 data = yield from i.__anext__()
-            except (StopAsyncIteration, asyncio.CancelledError):
+            except (StopAsyncIteration, asyncio.TimeoutError):
                 break
             else:
-                asyncio.async(self.channel.put(data))
+                yield from self.channel.put(data)
         self.running = False
 
     def stop(self):

--- a/aiodocker/exceptions.py
+++ b/aiodocker/exceptions.py
@@ -1,0 +1,9 @@
+class DockerError(Exception):
+
+    def __init__(self, status, data, *args):
+        super().__init__(*args)
+        self.status = status
+        self.message = data['message']
+
+    def __repr__(self):
+        return 'DockerError({}, {!r})'.format(self.status, self.message)

--- a/aiodocker/jsonstream.py
+++ b/aiodocker/jsonstream.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 
+import aiohttp.errors
+
 
 class JsonStreamResult(object):
     def __init__(self, response, transform=None):
@@ -15,7 +17,10 @@ class JsonStreamResult(object):
     @asyncio.coroutine
     def __anext__(self):
         while self._open:
-            data = yield from self.response.content.readany()
+            try:
+                data = yield from self.response.content.readline()
+            except aiohttp.errors.ClientDisconnectedError:
+                data = None
             if not data:
                 self._open = False
                 break

--- a/aiodocker/jsonstream.py
+++ b/aiodocker/jsonstream.py
@@ -1,33 +1,37 @@
 import asyncio
 import json
+import logging
 
 import aiohttp.errors
 
+log = logging.getLogger(__name__)
 
-class JsonStreamResult(object):
+
+class JsonStreamResult:
     def __init__(self, response, transform=None):
         self.response = response
         self.transform = transform or (lambda x: x)
 
-    @asyncio.coroutine
-    def __aiter__(self):
-        self._open = True
-        return self
-
-    @asyncio.coroutine
-    def __anext__(self):
-        while self._open:
+    async def fetch(self):
+        while True:
             try:
-                data = yield from self.response.content.readline()
-            except aiohttp.errors.ClientDisconnectedError:
-                data = None
-            if not data:
-                self._open = False
+                data = await self.response.content.readline()
+                if not data:
+                    break
+            except (aiohttp.errors.ClientDisconnectedError,
+                    aiohttp.errors.ServerDisconnectedError):
                 break
-            return self.transform(json.loads(data.decode('utf8')))
+            yield self.transform(json.loads(data.decode('utf8')))
 
-        yield from self.response.release()
-        raise StopAsyncIteration
+    async def close(self):
+        await self.response.release()
 
-    def close(self):
-        self.response.close()
+
+async def json_stream_result(response, transform=None, stream=True):
+    json_stream = JsonStreamResult(response, transform)
+    if stream:
+        return json_stream
+    data = []
+    async for obj in json_stream.fetch():
+        data.append(obj)
+    return data

--- a/aiodocker/jsonstream.py
+++ b/aiodocker/jsonstream.py
@@ -23,3 +23,6 @@ class JsonStreamResult(object):
 
         yield from self.response.release()
         raise StopAsyncIteration
+
+    def close(self):
+        self.response.close()

--- a/aiodocker/jsonstream.py
+++ b/aiodocker/jsonstream.py
@@ -24,7 +24,10 @@ class JsonStreamResult:
             yield self.transform(json.loads(data.decode('utf8')))
 
     async def close(self):
-        await self.response.release()
+        # response.release() indefinitely hangs because the server is sending
+        # an infinite stream of messages.
+        # (see https://github.com/KeepSafe/aiohttp/issues/739)
+        await self.response.close()
 
 
 async def json_stream_result(response, transform=None, stream=True):

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -17,3 +17,30 @@ def identical(d1, d2):
         return all((identical(x, y) for (x, y) in pairs))
 
     return d1 == d2
+
+
+_true_strs = frozenset(['true', 'yes', '1'])
+_false_strs = frozenset(['false', 'no', '0'])
+
+def human_bool(s):
+    if isinstance(s, str):
+        if s.lower() in _true_strs:
+            return True
+        if s.lower() in _false_strs:
+            return False
+        raise ValueError(f'Cannot interpret {s!r} as boolean.')
+    else:
+        return bool(s)
+
+
+def httpize(d: dict):
+    if d is None:
+        return None
+    converted = {}
+    for k, v in d.items():
+        if isinstance(v, bool):
+            v = '1' if v else '0'
+        if not isinstance(v, str):
+            v = str(v)
+        converted[k] = v
+    return converted

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,15 @@ services:
     build: .
     links:
       - docker
+      - registry
     volumes:
       - "./:/usr/src/aiodocker"
     environment:
       DOCKER_HOST: "http://docker:2375"
-
+      DOCKER_REGISTRY: "registry:5000"
+    command: py.test
   docker:
-    image: docker:dind
-    privileged: true
+    image: docker
+    command: "--insecure-registry registry:5000"
+  registry:
+    image: registry

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aiohttp>=0.9.0
+aiohttp>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-aiohttp>=1.1.0
+aiohttp>=1.1
+async_timeout

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,19 @@ long_description = "AsyncIO Docker bindings"
 setup(
     name="aiodocker",
     version=version,
-    packages=['aiodocker',],  # This is empty without the line below
     author="Paul Tagliamonte",
     author_email="paultag@debian.org",
     long_description=long_description,
-    description='does some stuff with things & stuff',
+    description="Provides coroutine-based API wrapper for Docker daemons",
     license="Expat",
     url="",
-    platforms=['any']
+    platforms=['any'],
+    packages=[
+        'aiodocker',
+    ],
+    python_requires='>=3.6',
+    install_requires=[
+        'aiohttp>=1.1',
+        'async_timeout',
+    ],
 )


### PR DESCRIPTION
I have added support for volumes API and polished streaming results for graceful shutdown, based on zbyte64's fork. I also have wrapped exceptions in "DockerError". Most string interpolation code are rewritten using Python 3.6's f-string literals and the streaming result is now handled via asynchronous generators (`yield` in `async def` functions).

Though I still need to add test cases, I'd like you to review the changes and discuss if my approach aligns with your direction (and if this could be merged eventually of course). Please feel free to add your opinions about improvements you want for this PR.

There seems to be different forks that adds different functionalities (e.g., detailed filtering condition support in logs API in [findmine/aiodocker](https://github.com/findmine/aiodocker)'s expansion branch). Before multiple forks diverge out too much, I think we need to discuss on what the maintainer thinks for next steps.